### PR TITLE
Feature/fixup master

### DIFF
--- a/src/mbbeagle.c
+++ b/src/mbbeagle.c
@@ -804,8 +804,10 @@ int TreeCondLikes_Beagle (Tree *t, int division, int chain)
     TreeNode            *p;
     ModelInfo           *m;
     unsigned            chil1Step, chil2Step;
+    int                 *isScalerNode;
     
     m = &modelSettings[division];
+    isScalerNode = m->isScalerNode[chain];
     
     for (i=0; i<t->nIntNodes; i++)
         {
@@ -880,7 +882,7 @@ int TreeCondLikes_Beagle (Tree *t, int division, int chain)
                 operations.child1TransitionMatrix++;
                 operations.child2Partials+=chil2Step;
                 operations.child2TransitionMatrix++;
-                if (m->isScalerNode == YES)
+                if (isScalerNode[p->index] == YES)
                     {
                     operations.destinationScaleWrite++;
                     cumulativeScaleIndex++;

--- a/src/mbbeagle.c
+++ b/src/mbbeagle.c
@@ -265,7 +265,7 @@ void LaunchBEAGLELogLikeForDivision(int chain, int d, ModelInfo* m, Tree* tree, 
             }
 
         if (beagleScalingFrequency != 0 && 
-            m->computeCount[chain] % (beagleScalingFrequency) == 0)
+            m->beagleComputeCount[chain] % (beagleScalingFrequency) == 0)
             {
             m->rescaleFreqOld = rescaleFreqNew = m->rescaleFreq[chain];
             for (i=0; i<tree->nIntNodes; i++)
@@ -349,7 +349,7 @@ void LaunchBEAGLELogLikeForDivision(int chain, int d, ModelInfo* m, Tree* tree, 
         }
     
     /* Count number of evaluations */
-    m->computeCount[chain]++;
+    m->beagleComputeCount[chain]++;
 }
 
 
@@ -855,7 +855,7 @@ int TreeCondLikes_Beagle (Tree *t, int division, int chain)
             /* Now deal with scalers */
             m->unscaledNodes[chain][p->index] = 1 + m->unscaledNodes[chain][p->left->index] + m->unscaledNodes[chain][p->right->index];
 
-            if (m->unscaledNodes[chain][p->index] >= m->rescaleFreq)
+            if (m->unscaledNodes[chain][p->index] >= m->rescaleFreq[chain])
                 {
                 m->unscaledNodes[chain][p->index] = 0;
                 operations.destinationScaleWrite = m->nodeScalerIndex[chain][p->index];
@@ -880,7 +880,7 @@ int TreeCondLikes_Beagle (Tree *t, int division, int chain)
                 operations.child1TransitionMatrix++;
                 operations.child2Partials+=chil2Step;
                 operations.child2TransitionMatrix++;
-                if (p->scalerNode == YES)
+                if (m->isScalerNode == YES)
                     {
                     operations.destinationScaleWrite++;
                     cumulativeScaleIndex++;

--- a/src/mbbeagle.h
+++ b/src/mbbeagle.h
@@ -21,4 +21,7 @@ int    TreeCondLikes_Beagle (Tree *t, int division, int chain);
 int    TreeLikelihood_Beagle (Tree *t, int division, int chain, MrBFlt *lnL, int whichSitePats);
 int    TreeTiProbs_Beagle (Tree *t, int division, int chain);
 
+extern char *beagleGetVersion (void);
+
 #endif  /* __MBBEAGLE_H__ */
+

--- a/src/mbbeagle.h
+++ b/src/mbbeagle.h
@@ -21,6 +21,4 @@ int    TreeCondLikes_Beagle (Tree *t, int division, int chain);
 int    TreeLikelihood_Beagle (Tree *t, int division, int chain, MrBFlt *lnL, int whichSitePats);
 int    TreeTiProbs_Beagle (Tree *t, int division, int chain);
 
-extern char *beagleGetVersion(void);
-
 #endif  /* __MBBEAGLE_H__ */


### PR DESCRIPTION
I now fixed the node index, which was missing. I also changed the header back to include the external declaration of the beagle version function (defined in the beagle library) (otherwise I get a C99 compliance warning when compiling).

I ran the code on primates.nex and confirmed that the likelihoods are the same up to about the third decimal. The differences in decimals beyond that are very likely due to the difference in precision (single-precision without beagle, double-precision with beagle - beagle does not do single-precision float as far as I know), and of no concern.