### PR TITLE
Removed superfluous variables

### DIFF
--- a/src/likelihood.c
+++ b/src/likelihood.c
@@ -5265,7 +5265,7 @@ int CondLikeScaler_NUC4_AVX (TreeNode *p, int division, int chain)
 {
     int             c, k;
     CLFlt           *scP, *lnScaler;
-    __m256          *clPtr, **clP, *scP_AVX, m1; /* , m2; */
+    __m256          *clPtr, **clP, *scP_AVX, m1;
     ModelInfo       *m;
     
     m = &modelSettings[division];
@@ -6745,7 +6745,7 @@ int Likelihood_NUC4_FMA (TreeNode *p, int division, int chain, MrBFlt *lnL, int 
     MrBFlt          freq, *bs, pInvar=0.0, like, likeI;
     CLFlt           *lnScaler, *nSitesOfPat, *lnL_Vec, *lnLI_Vec;
     __m256          *clPtr, **clP, *clInvar=NULL;
-    __m256          /* m1, */ mA, mC, mG, mT, mFreq, mPInvar=_mm256_set1_ps(0.0f), mLike;
+    __m256          mA, mC, mG, mT, mFreq, mPInvar=_mm256_set1_ps(0.0f), mLike;
     ModelInfo       *m;
     
 #   if defined (FAST_LOG)


### PR DESCRIPTION
In SSE/AVX/FMA code, there were two superfluous variables declared but not used in two different functions. They generated warnings so they were commented out. In my thinking, however, it is bad practice to leave code that is commented out in the develop or release branches, particularly if there is no comment indicating whether it is a temporary, unchecked fix or believed to be a permanent fix.

In the code in my pull request, I checked that the variables should be removed, and then removed them completely.