### PR TITLE
Patch/clockprior test

### DIFF
--- a/src/command.c
+++ b/src/command.c
@@ -369,7 +369,7 @@ CmdType             *commandPtr; /* Points to the commands array entry which cor
 ParmInfoPtr         paramPtr;    /* Points to paramTable table array entry which corresponds to currently processed parameter of current command */
 TreeNode            *pPtr, *qPtr;
 
-enum ConstraintType     consrtainType; /* Used only in processing of constraine command to indicate what is the type of constrain */
+enum ConstraintType constraintType; /* Used only in processing of constraint command to indicate the type of constraint */
 
 
 int AddToGivenSet (int i, int j, int k, int id, int *Set)
@@ -2392,7 +2392,7 @@ int DoConstraint (void)
     int         i, howMany;
     int         *tset;
 
-    if (consrtainType == PARTIAL)
+    if (constraintType == PARTIAL)
         tset=tempSetNeg;
     else
         tset=tempSet;
@@ -2426,19 +2426,19 @@ int DoConstraint (void)
         return (ERROR);
         }
 
-    if (consrtainType == HARD)
+    if (constraintType == HARD)
         {
         if (howMany == numTaxa)
             {
             /* We allow this so we can report states from and calibrate root */
             }
         
-        } /*end consrtainType == HARD */
-    else if (consrtainType == PARTIAL)
+        } /*end constraintType == HARD */
+    else if (constraintType == PARTIAL)
         {
         if (howMany == 1)
             {
-            MrBayesPrint ("%s   This partial constraint include only one taxa. It is alwayes satisfied and will not be defined.\n", spacer);
+            MrBayesPrint ("%s   This partial constraint includes only one taxon. It is always satisfied and will not be defined.\n", spacer);
             return (ERROR);
             }
 
@@ -2461,11 +2461,11 @@ int DoConstraint (void)
             return (ERROR);
             }
         }
-    else if (consrtainType == NEGATIVE)
+    else if (constraintType == NEGATIVE)
         {
         if (howMany == 1)
             {
-            MrBayesPrint ("%s   Negative constraint should include more than one taxa. Constraint will not be defined\n", spacer);
+            MrBayesPrint ("%s   Negative constraint should include more than one taxon. Constraint will not be defined\n", spacer);
             return (ERROR);
             }
         }
@@ -2479,7 +2479,7 @@ int DoConstraint (void)
 
     /* store tempSet */
     AddBitfield (&definedConstraint, numDefinedConstraints, tempSet, numTaxa);
-    if (consrtainType == PARTIAL)
+    if (constraintType == PARTIAL)
         {
         AddBitfield (&definedConstraintTwo, numDefinedConstraints, tempSetNeg, numTaxa);
         }
@@ -2520,7 +2520,7 @@ int DoConstraint (void)
     definedConstraintsType = (enum ConstraintType *) SafeRealloc((void *)(definedConstraintsType), (size_t)numDefinedConstraints*sizeof(enum ConstraintType));
     if (definedConstraintsType==NULL)
         return ERROR;
-    definedConstraintsType[numDefinedConstraints-1] = consrtainType;
+    definedConstraintsType[numDefinedConstraints-1] = constraintType;
 
     definedConstraintPruned = (BitsLong **) SafeRealloc ((void *)(definedConstraintPruned), (size_t)numDefinedConstraints*sizeof(BitsLong *));
     if (definedConstraintPruned==NULL)
@@ -2584,7 +2584,7 @@ int DoConstraintParm (char *parmName, char *tkn)
             for (i=0; i<numTaxa; i++)
                 tempSet[i] = 0;
 
-            consrtainType = HARD; /* set default constrain type */
+            constraintType = HARD; /* set default constrain type */
             tempSetCurrent=tempSet;
             fromI = toJ = everyK = -1;
             foundDash = foundSlash = NO;
@@ -2638,19 +2638,19 @@ int DoConstraintParm (char *parmName, char *tkn)
                 for (i=0; i<numTaxa; i++)
                     tempSetNeg[i] = 0;
 
-                consrtainType = PARTIAL;
+                constraintType = PARTIAL;
                 expecting = Expecting(EQUALSIGN);
                 expecting |= Expecting(ALPHA);
                 }
             else if (IsSame ("Hard", tkn) == SAME)
                 {
-                consrtainType = HARD;
+                constraintType = HARD;
                 expecting = Expecting(EQUALSIGN);
                 expecting |= Expecting(ALPHA);
                 }
             else if (IsSame ("Negative", tkn) == SAME)
                 {
-                consrtainType = NEGATIVE;
+                constraintType = NEGATIVE;
                 expecting = Expecting(EQUALSIGN);
                 expecting |= Expecting(ALPHA);
                 }
@@ -2701,7 +2701,7 @@ int DoConstraintParm (char *parmName, char *tkn)
 
             expecting  = Expecting(ALPHA);
             expecting |= Expecting(NUMBER);
-            if (consrtainType != PARTIAL || foundColon == YES)
+            if (constraintType != PARTIAL || foundColon == YES)
                 expecting |= Expecting(SEMICOLON);
             else
                 expecting |= Expecting(COLON);
@@ -2814,7 +2814,7 @@ int DoConstraintParm (char *parmName, char *tkn)
             expecting |= Expecting(NUMBER);
             expecting |= Expecting(DASH);
             expecting |= Expecting(BACKSLASH);
-            if (consrtainType != PARTIAL || foundColon == YES)
+            if (constraintType != PARTIAL || foundColon == YES)
                 expecting |= Expecting(SEMICOLON);
             else
                 expecting |= Expecting(COLON);

--- a/src/likelihood.c
+++ b/src/likelihood.c
@@ -70,6 +70,10 @@ int       RemoveNodeScalers_SSE(TreeNode *p, int division, int chain);
 int       RemoveNodeScalers_AVX(TreeNode *p, int division, int chain);
 #endif
 void      ResetSiteScalers (ModelInfo *m, int chain);
+int       SetBinaryQMatrix (MrBFlt **a, int whichChain, int division);
+int       SetNucQMatrix (MrBFlt **a, int n, int whichChain, int division, MrBFlt rateMult, MrBFlt *rA, MrBFlt *rS);
+int       SetStdQMatrix (MrBFlt **a, int nStates, MrBFlt *bs, int cType);
+int       SetProteinQMatrix (MrBFlt **a, int n, int whichChain, int division, MrBFlt rateMult);
 int       UpDateCijk (int whichPart, int whichChain);
 
 

--- a/src/likelihood.c
+++ b/src/likelihood.c
@@ -43,6 +43,12 @@
 
 #define LIKE_EPSILON                1.0e-300
 
+/* global variables declared here */
+CLFlt     *preLikeL;                  /* precalculated cond likes for left descendant */
+CLFlt     *preLikeR;                  /* precalculated cond likes for right descendant*/
+CLFlt     *preLikeA;                  /* precalculated cond likes for ancestor        */
+
+/* global variables used here but declared elsewhere */
 extern int      *chainId;
 extern int      numLocalChains;
 extern int      rateProbRowSize;            /* size of rate probs for one chain one state   */

--- a/src/likelihood.h
+++ b/src/likelihood.h
@@ -39,10 +39,6 @@
 #define TG                          14
 #define TT                          15
 
-CLFlt     *preLikeL;                  /* precalculated cond likes for left descendant */
-CLFlt     *preLikeR;                  /* precalculated cond likes for right descendant*/
-CLFlt     *preLikeA;                  /* precalculated cond likes for ancestor        */
-
 int       CondLikeDown_Bin (TreeNode *p, int division, int chain);
 #if defined (SSE_ENABLED)
 int       CondLikeDown_Bin_SSE (TreeNode *p, int division, int chain);

--- a/src/mcmc.c
+++ b/src/mcmc.c
@@ -250,7 +250,7 @@ void      TouchAllPartitions (void);
 void      TouchAllTrees (int chain);
 void      TouchEverything (int chain);
 
-/* globals */
+/* globals declared here and used elsewhere */
 int             *bsIndex;                    /* compressed std stat freq index               */
 Chain           chainParams;                 /* parameters of Markov chain                   */
 int             *compCharPos;                /* char position in compressed matrix           */
@@ -271,6 +271,11 @@ int             *tiIndex;                    /* compressed std char ti index    
 #if defined (BEAGLE_ENABLED)
 int             recalcScalers;               /* shoud we recalculate scalers for current state YES/NO */
 #endif
+
+/* globals used here but declared elsewhere (in likelihood.c) */
+extern CLFlt     *preLikeL;                  /* precalculated cond likes for left descendant */
+extern CLFlt     *preLikeR;                  /* precalculated cond likes for right descendant*/
+extern CLFlt     *preLikeA;                  /* precalculated cond likes for ancestor        */
 
 /* local (to this file) variables */
 int             numLocalChains;              /* number of Markov chains                      */

--- a/src/model.c
+++ b/src/model.c
@@ -145,12 +145,14 @@ MrBFlt          vtPi[20];                    /* stationary frequencies for VT mo
 MrBFlt          blosPi[20];                  /* stationary frequencies for Blosum62 model    */
 MrBFlt          lgPi[20];                    /* stationary frequencies for LG model          */
 
-/* parser flags and variables */
-int         fromI, toJ, foundDash, foundComma, foundEqual, foundBeta,
-            foundAaSetting, foundExp, modelIsFixed, linkNum, foundLeftPar, tempNumStates, isNegative,
+/* parser flags and variables only used in this file */
+int         foundComma, foundBeta, foundAaSetting, modelIsFixed, linkNum, foundLeftPar, tempNumStates,
             foundBSNum[999], foundDSNum[999], foundFSNum[999], foundBSTime[999], foundDSTime[999], foundFSTime[999];
 MrBFlt      tempStateFreqs[200], tempAaModelPrs[10];
 char        colonPr[100], clockPr[30];
+
+/* parser flags and variables shared with command.c */
+extern int  fromI, toJ, foundDash, foundExp, foundEqual, isNegative;
 
 /* other local variables (this file) */
 MrBFlt          empiricalFreqs[200];         /* emprical base frequencies for partition                 */

--- a/src/model.c
+++ b/src/model.c
@@ -19662,17 +19662,19 @@ int SetMoves (void)
             if (moveTypes[i].isApplicable(param) == NO)
                 continue;
             for (j=0; j<moveTypes[i].nApplicable; j++)
+                {
                 if (moveTypes[i].applicableTo[j] == param->paramId)
                     {
                     numApplicableMoves++;
                     break;
                     }
+                }
             }
         }
 
     /* then allocate space for move pointers */
     moves = (MCMCMove **) SafeMalloc (numApplicableMoves * sizeof (MCMCMove *));
-    if (!moves)
+    if (!moves && numApplicableMoves > 0)   /* in the middle of defining a model, numApplicableMoves can be 0 */
         {
         MrBayesPrint ("%s   Problem allocating moves\n", spacer);
         return (ERROR);
@@ -23237,10 +23239,24 @@ int ShowParameters (int showStartVals, int showMoves, int showAllAvailable)
             else if (!strcmp(mp->topologyPr,"Speciestree"))
                 MrBayesPrint ("%s            Prior      = Topology constrained to fold within species tree\n", spacer);
             else if (!strcmp(mp->topologyPr,"Constraints"))
-                MrBayesPrint ("%s            Prior      = Prior on topologies obeys constraints\n", spacer);
+                MrBayesPrint ("%s            Prior      = Prior on topology obeys the following constraints:\n", spacer);
             else
                 MrBayesPrint ("%s            Prior      = Prior is fixed to the topology of user tree '%s'\n", spacer,
                                                     userTree[mp->topologyFix]->name);
+            if (!strcmp(mp->topologyPr,"Constraints"))
+                {
+                for (a=0; a<numDefinedConstraints; ++a)
+                    {
+                    if (mp->activeConstraints[a] == NO)
+                        continue;
+                    if (definedConstraintsType[a] == HARD)
+                        MrBayesPrint ("%s                         -- Hard constraint \"%s\"\n", spacer, constraintNames[a]);
+                    else if (definedConstraintsType[a] == PARTIAL)
+                        MrBayesPrint ("%s                         -- Partial constraint \"%s\"\n", spacer, constraintNames[a]);
+                    else /* if (true) */
+                        MrBayesPrint ("%s                         -- Negative constraint \"%s\"\n", spacer, constraintNames[a]);
+                    }
+                }
             }
         else if (j == P_BRLENS)
             {


### PR DESCRIPTION
This fixes a number of minor issues (see commit comments), which occurred when I ran the clockprior_test.nex test file to check that the igr relaxed clock implementation had not been corrupted by recent code changes (it appears to be OK). We now print correct info about taxon exclusion when sumt is run with some taxa not present in the trees or deleted. We also deal with cases when, during model specification, there is not a single applicable move in an intermediate step. I also fixed a couple of problems with the code figuring out the applicability of tree moves to trees. Finally, we now print correct line numbers and column positions of errors during parsing.