### PR TITLE
Possible fix for segmentation fault in FMA code path

### DIFF
--- a/src/mcmc.c
+++ b/src/mcmc.c
@@ -5922,7 +5922,7 @@ int InitChainCondLikes (void)
                         numReps = m->numRateCats * m->numOmegaCats;
                     k = m->numVecChars * m->numFloatsPerVec * m->numModelStates * numReps;
                     
-                    if (m->useVec == VEC_AVX)
+                    if (m->useVec == VEC_AVX || m->useVec == VEC_FMA)
                         m->condLikes[i] = (CLFlt*) AlignedMalloc (k * sizeof(CLFlt), 32);
                     else
                         m->condLikes[i] = (CLFlt*) AlignedMalloc (k * sizeof(CLFlt), 16);
@@ -6608,7 +6608,7 @@ int InitInvCondLikes (void)
         if ( m->useVec != VEC_NONE )
             {
             c1 = m->numVecChars * m->numFloatsPerVec * m->numModelStates;
-            if (m->useVec == VEC_AVX)
+            if (m->useVec == VEC_AVX || m->useVec == VEC_FMA)
                 m->invCondLikes = (CLFlt *) AlignedMalloc (c1 * sizeof(CLFlt), 32);
             else
                 m->invCondLikes = (CLFlt *) AlignedMalloc (c1 * sizeof(CLFlt), 16);


### PR DESCRIPTION
The FMA code caused a segmentation fault when calling _mm256_mul_ps() in
CondLikeDown_NUC4_FMA().  This was likely caused by using FMA SIMD
instructions on misaligned data.

Upon debugging this, I noticed that AlignedMalloc() was being called
with an alignment of 16 rather than 32 for some of the data.  This was
due to two if-statements only testing for AVX and not also for FMA.

The patch fixes the two if-statements and the resulting binary no longer
exhibit the segmentation fault.

I noted that another if-statement already had this extra test for FMA
included.

This is primarily relating to issue #74 and possibly also to issue #65.

(the commit message said "PR" rather than "issue" on the line above this, this was a mistyping)