### PR TITLE
Increase size of a couple of string buffers

### DIFF
--- a/src/mcmc.c
+++ b/src/mcmc.c
@@ -16064,7 +16064,7 @@ int RunChain (RandLong *seed)
     /* Stepping-stone sampling variables */
     int         run, samplesCountSS=0, stepIndexSS=0, numGenInStepSS=0, numGenOld, lastStepEndSS=0, numGenInStepBurninSS=0;
     MrBFlt      stepLengthSS=0, meanSS, varSS, *tempX;
-    char        ckpFileName[220], bkupFileName[220];
+    char        ckpFileName[220], bkupFileName[234];
 
 #   if defined (BEAGLE_ENABLED)
 #       ifdef DEBUG_BEAGLE

--- a/src/sumpt.c
+++ b/src/sumpt.c
@@ -4849,7 +4849,7 @@ int DoSumt (void)
     MrBFlt          f, var_s, sum_s, stddev_s=0.0, sumsq_s, sumStdDev=0.0, maxStdDev=0.0, sumPSRF=0.0,
                     maxPSRF=0.0, avgStdDev=0.0, avgPSRF=0.0, min_s=0.0, max_s=0.0, numPSRFSamples=0, min;
     PartCtr         *x;
-    char            *s=NULL, tempName[120], fileName[120], treeName[100], divString[100];
+    char            *s=NULL, tempName[137], fileName[120], treeName[100], divString[100];
     char            *tempStr=NULL; /*not static because error ext is handled*/
     int             tempStrLength;
     FILE            *fp=NULL;


### PR DESCRIPTION
... to allow strings to be safely sprintf-ed to them.  Using the buffer
sizes that GCC 8 is suggesting.