### PR TITLE
Fixed issue-117

### DIFF
--- a/src/model.c
+++ b/src/model.c
@@ -1899,7 +1899,8 @@ int CheckModel (void)
                 {
                 MrBayesPrint("%s   WARNING: You are using a coalescent model but the clock rate is fixed to 1.0.\n", spacer);
                 MrBayesPrint("%s      This is likely to be incorrect unless you have set the population size prior\n", spacer);
-                MrBayesPrint("%s      ('prset popsizepr') to reflect an appropriate prior on theta. \n", spacer);
+                MrBayesPrint("%s      ('prset popsizepr') to reflect an appropriate prior on theta. Please check that \n", spacer);
+                MrBayesPrint("%s      the prior on theta is reasonable for your data.\n", spacer);
 
                 if (noWarn == NO)
                     {

--- a/src/model.c
+++ b/src/model.c
@@ -1895,21 +1895,24 @@ int CheckModel (void)
         if ((!strcmp(modelParams[t->relParts[0]].clockPr,"Coalescence") || !strcmp(modelParams[t->relParts[0]].clockPr,"Speciestreecoalescence"))
             && !strcmp(modelParams[t->relParts[0]].clockRatePr, "Fixed") && AreDoublesEqual(modelParams[t->relParts[0]].clockRateFix, 1.0, 1E-6) == YES)
             {
-            MrBayesPrint("%s   WARNING: You are using a coalescent model but the clock rate is fixed to 1.0.\n", spacer);
-            MrBayesPrint("%s      This is likely to be incorrect unless you have set the population size prior\n", spacer);
-            MrBayesPrint("%s      ('prset popsizepr') to reflect an appropriate prior on theta. \n", spacer);
-
-            if (noWarn == NO)
+            if (i == 0) // We only warn for the first tree
                 {
-                answer = WantTo("Do you want to continue with the run regardless");
-                if (answer == YES)
+                MrBayesPrint("%s   WARNING: You are using a coalescent model but the clock rate is fixed to 1.0.\n", spacer);
+                MrBayesPrint("%s      This is likely to be incorrect unless you have set the population size prior\n", spacer);
+                MrBayesPrint("%s      ('prset popsizepr') to reflect an appropriate prior on theta. \n", spacer);
+
+                if (noWarn == NO)
                     {
-                    MrBayesPrint("%s   Continuing with the run...\n\n", spacer);
-                    }
-                else
-                    {
-                    MrBayesPrint("%s   Stopping the run...\n\n", spacer);
-                    return (ERROR);
+                    answer = WantTo("Do you want to continue with the run regardless");
+                    if (answer == YES)
+                        {
+                        MrBayesPrint("%s   Continuing with the run...\n\n", spacer);
+                        }
+                    else
+                        {
+                        MrBayesPrint("%s   Stopping the run...\n\n", spacer);
+                        return (ERROR);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Now there is only one warning issued. The warning is appropriate; it is important that the user has set a correct theta prior under these conditions. We could check that the default prior has been changed, which might indicate that an appropriate prior has been set. But the default prior may actually be appropriate, so this might not be the best behavior.