### PR TITLE
Issue-118.

### DIFF
--- a/src/command.c
+++ b/src/command.c
@@ -8217,6 +8217,11 @@ int DoTreeParm (char *parmName, char *tkn)
                 MrBayesPrint ("%s   Overwriting tree '%s'.\n", spacer, userTree[treeIndex]);
                 FreePolyTree (userTree[treeIndex]);
                 }
+            if (treeIndex > MAX_NUM_USERTREES)
+                {
+                MrBayesPrint ("%s   MrBayes can only store %d user trees.\n", spacer, MAX_NUM_USERTREES);
+                return (ERROR);
+                }
             if ((userTree[treeIndex] = AllocatePolyTree (numTaxa)) == NULL)
                 return (ERROR);
             t = userTree[treeIndex];


### PR DESCRIPTION
I added a check so that MrBayes does not read in more user trees than there is storage space allocated for (200 user trees, in MAX_NUM_USERTREES. Please verify that it solves the issue and then pull.