### PR TITLE
Invoked printing of the Reallocation of zero size warning again

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -1569,7 +1569,7 @@ void *SafeRealloc (void *ptr, size_t s)
 
     if (s == 0)
         {
-        //MrBayesPrint ("%s   WARNING: Reallocation of zero size attempted. This is probably a bug. Problems may follow.\n", spacer);
+        MrBayesPrint ("%s   WARNING: Reallocation of zero size attempted. This is probably a bug. Problems may follow.\n", spacer);
         free (ptr);
         return NULL;
         }


### PR DESCRIPTION
Issue 70 was fixed some time ago. We can invoke the printing of the warning message again, it is not triggered by the commands described in issue 70.