### PR TITLE
Covarion model not supported by Beagle causes crash

### DIFF
--- a/src/mcmc.c
+++ b/src/mcmc.c
@@ -5837,7 +5837,12 @@ int InitChainCondLikes (void)
                     {
                     MrBayesPrint ("%s   Non-beagle version of conditional likelihood calculator will be used for division %d due to\n", spacer, d+1);
                     MrBayesPrint ("%s   request of reporting 'ancestral states', 'site rates', 'pos selection' or 'site omegas'.\n", spacer);
-                    }                
+                    }
+                else if (m->switchRates != NULL)
+                    {
+                    MrBayesPrint ("%s   Non-beagle version of conditional likelihood calculator will be used for division %d due to\n", spacer, d+1);
+                    MrBayesPrint ("%s   the covarion model not being supported in the current beagle implementation in MrBayes.\n", spacer);
+                    }
                 else if (m->gibbsGamma == NO)
                     m->useBeagle = YES;
                 }


### PR DESCRIPTION
This patch fixes issue #160. If the covarion model is selected, MrBayes will now switch to the default likelihood calculator, even when beagle is enabled. The covarion model is not supported correctly in the current beagle implementation in MrBayes, so previously this caused a crash in the beagle-enabled version of the program.