### PR TITLE
Fixed issue with checkpointing when root age is calibrated

### DIFF
--- a/src/utils.c
+++ b/src/utils.c
@@ -6384,7 +6384,7 @@ int ResetRootHeight (Tree *t, MrBFlt rootHeight)
 
     if (t->isClock == NO)
         return ERROR;
-    
+
     /* make sure node depths are set */
     for (i=0; i<t->nNodes-1; i++)
         {


### PR DESCRIPTION
When start values are read in, there are problems in the checking of the consistency between the clock rate and the tree age settings. Among other things, this causes problems with checkpointing in these types of models. The tree age and clock rate parameters are set in different commands, so the consistency check needs to be deferred until just before the start of the chain, when all model settings have been finalized. This is taken care of in this bug fix. Specifically, the check is implemented in the CheckModel function, which is called just before the chain starts, and checks the consistency of the model in cases where this cannot be done earlier.