### PR TITLE
Better checking of clock tree consistency

### DIFF
--- a/src/mcmc.c
+++ b/src/mcmc.c
@@ -2584,6 +2584,10 @@ int DoMcmc (void)
             goto errorExit;
         }
 
+    /* Check again that the model is consistent after potentially resetting starting values (co-dependencies etc) */
+    if (CheckModel() == ERROR)
+        goto errorExit;
+ 
 #ifndef NDEBUG
     /* checking tree consistency for debug purposes */
     for (i=0; i<numParams; i++)
@@ -2593,7 +2597,7 @@ int DoMcmc (void)
         }
 #endif
 
-    /* Initialize vectors of print parameters */
+   /* Initialize vectors of print parameters */
     if (InitPrintParams () == ERROR)
         goto errorExit;
     

--- a/src/mcmc.c
+++ b/src/mcmc.c
@@ -2597,7 +2597,7 @@ int DoMcmc (void)
         }
 #endif
 
-   /* Initialize vectors of print parameters */
+    /* Initialize vectors of print parameters */
     if (InitPrintParams () == ERROR)
         goto errorExit;
     

--- a/src/model.c
+++ b/src/model.c
@@ -167,7 +167,9 @@ int             *stateSize;                  /* # states for each compressed cha
 // int          foundCurly;
 // char         *plotTokenP;                 /* plotToken[CMD_STRING_LENGTH];*/
 
+#if defined (MPI_ENABLED)
 extern int      numLocalChains; //for debugging
+#endif
 
 /*-----------------------------------------------------------------------
 |
@@ -1952,7 +1954,11 @@ int CheckModel (void)
      */
     for (i=0; i<numTrees; i++)
         {
-        for (int chain_index=0; chain_index<numLocalChains; chain_index++) {
+#if defined (MPI_ENABLED)
+            for (int chain_index=0; chain_index<numLocalChains; chain_index++) {
+#else
+            for (int chain_index=0; chain_index<numGlobalChains; chain_index++) {
+#endif
             t = GetTreeFromIndex(i,chain_index,0);
             clockRate = *GetParamVals(modelSettings[t->relParts[0]].clockRate, chain_index, 0);
             treeAge = t->root->left->nodeDepth / clockRate;

--- a/src/model.c
+++ b/src/model.c
@@ -167,6 +167,7 @@ int             *stateSize;                  /* # states for each compressed cha
 // int          foundCurly;
 // char         *plotTokenP;                 /* plotToken[CMD_STRING_LENGTH];*/
 
+extern int      numLocalChains; //for debugging
 
 /*-----------------------------------------------------------------------
 |

--- a/src/model.c
+++ b/src/model.c
@@ -1963,9 +1963,17 @@ int CheckModel (void)
             clockRate = *GetParamVals(modelSettings[t->relParts[0]].clockRate, chain_index, 0);
             treeAge = t->root->left->nodeDepth / clockRate;
 #if defined (MPI_ENABLED)
-            printf("proc_id: %d, chain: %d -- clockRate=%lf, treeAge=%lf\n", proc_id, chain_index, clockRate, treeAge);
+            printf("proc_id: %d, chain: %d, state 0 -- clockRate=%lf, treeAge=%lf, nodeDepth=%lf\n", proc_id, chain_index, clockRate, treeAge, t->root->left->nodeDepth);
 #else
-            printf("chain: %d -- clockRate=%lf, treeAge=%lf\n", chain_index, clockRate, treeAge);
+            printf("chain: %d, state 0 -- clockRate=%lf, treeAge=%lf, nodeDepth=%lf\n", chain_index, clockRate, treeAge, t->root->left->nodeDepth);
+#endif
+            t = GetTreeFromIndex(i,chain_index,1);
+            clockRate = *GetParamVals(modelSettings[t->relParts[0]].clockRate, chain_index, 1);
+            treeAge = t->root->left->nodeDepth / clockRate;
+#if defined (MPI_ENABLED)
+            printf("proc_id: %d, chain: %d, state 1 -- clockRate=%lf, treeAge=%lf, nodeDepth=%lf\n", proc_id, chain_index, clockRate, treeAge, t->root->left->nodeDepth);
+#else
+            printf("chain: %d, state 1 -- clockRate=%lf, treeAge=%lf, nodeDepth=%lf\n", chain_index, clockRate, treeAge, t->root->left->nodeDepth);
 #endif
         }
         t = GetTreeFromIndex(i,0,0);

--- a/src/model.c
+++ b/src/model.c
@@ -1967,14 +1967,6 @@ int CheckModel (void)
 #else
             printf("chain: %d, state 0 -- clockRate=%lf, treeAge=%lf, nodeDepth=%lf\n", chain_index, clockRate, treeAge, t->root->left->nodeDepth);
 #endif
-            t = GetTreeFromIndex(i,chain_index,1);
-            clockRate = *GetParamVals(modelSettings[t->relParts[0]].clockRate, chain_index, 1);
-            treeAge = t->root->left->nodeDepth / clockRate;
-#if defined (MPI_ENABLED)
-            printf("proc_id: %d, chain: %d, state 1 -- clockRate=%lf, treeAge=%lf, nodeDepth=%lf\n", proc_id, chain_index, clockRate, treeAge, t->root->left->nodeDepth);
-#else
-            printf("chain: %d, state 1 -- clockRate=%lf, treeAge=%lf, nodeDepth=%lf\n", chain_index, clockRate, treeAge, t->root->left->nodeDepth);
-#endif
         }
         t = GetTreeFromIndex(i,0,0);
         if (t->isClock == YES && t->isCalibrated == YES)

--- a/src/model.c
+++ b/src/model.c
@@ -1951,6 +1951,16 @@ int CheckModel (void)
      */
     for (i=0; i<numTrees; i++)
         {
+        for (int chain_index=0; chain_index<numLocalChains; chain_index++) {
+            t = GetTreeFromIndex(i,chain_index,0);
+            clockRate = *GetParamVals(modelSettings[t->relParts[0]].clockRate, chain_index, 0);
+            treeAge = t->root->left->nodeDepth / clockRate;
+#if defined (MPI_ENABLED)
+            printf("proc_id: %d, chain: %d -- clockRate=%lf, treeAge=%lf\n", proc_id, chain_index, clockRate, treeAge);
+#else
+            printf("chain: %d -- clockRate=%lf, treeAge=%lf\n", chain_index, clockRate, treeAge);
+#endif
+        }
         t = GetTreeFromIndex(i,0,0);
         if (t->isClock == YES && t->isCalibrated == YES)
             {

--- a/src/model.c
+++ b/src/model.c
@@ -1954,18 +1954,14 @@ int CheckModel (void)
      */
     for (i=0; i<numTrees; i++)
         {
-#if defined (MPI_ENABLED)
-            for (int chain_index=0; chain_index<numLocalChains; chain_index++) {
-#else
-            for (int chain_index=0; chain_index<numGlobalChains; chain_index++) {
-#endif
+        for (int chain_index=0; chain_index<numGlobalChains; chain_index++) {
             t = GetTreeFromIndex(i,chain_index,0);
             clockRate = *GetParamVals(modelSettings[t->relParts[0]].clockRate, chain_index, 0);
             treeAge = t->root->left->nodeDepth / clockRate;
 #if defined (MPI_ENABLED)
-            printf("proc_id: %d, chain: %d, state 0 -- clockRate=%lf, treeAge=%lf, nodeDepth=%lf\n", proc_id, chain_index, clockRate, treeAge, t->root->left->nodeDepth);
+            printf("proc_id: %d, chain: %d, state 0 -- clockRate=%lf, treeAge=%lf, nodeDepth=%lf, treeAge=%lf\n", proc_id, chain_index, clockRate, treeAge, t->root->left->nodeDepth, t->root->left->age);
 #else
-            printf("chain: %d, state 0 -- clockRate=%lf, treeAge=%lf, nodeDepth=%lf\n", chain_index, clockRate, treeAge, t->root->left->nodeDepth);
+            printf("chain: %d, state 0 -- clockRate=%lf, treeAge=%lf, nodeDepth=%lf, treeAge=%lf\n", chain_index, clockRate, treeAge, t->root->left->nodeDepth, t->root->left->age);
 #endif
         }
         t = GetTreeFromIndex(i,0,0);


### PR DESCRIPTION
Johanna Orsholm reported that checkpointing issues persist in the MPI version for certain clock tree models. I could not replicate the problem; the fix of the checkpointing issue in the serial version (see my previous pull request) appears also to have fixed it in the MPI version. Thus, it seems likely that Johanna is still running on the old code unintentionally; I have asked her to verify this.

However, when reviewing the code I discovered that the consistent check of clock tree models is currently done before the starting values are read in from a checkpoint file when a chain is continued (mcmc with append=yes). Therefore, I added a check after the starting values have been read in through an extra call to CheckModel. Also, in CheckModel I extended the check of the clock tree consistency to the starting values of all chains, because starting values are read in separately for each chain. It is not sufficient to just check the first chain, as done previously (and sufficient for auto-generated starting values).

This pull request contains these updates to the consistency check.