### PR TITLE
Undefined SSE_ENABLED by default

### DIFF
--- a/src/bayes.h
+++ b/src/bayes.h
@@ -4,14 +4,14 @@
 #ifdef HAVE_CONFIG_H
 #   include "config.h"
 #   define VERSION_NUMBER  PACKAGE_VERSION
-#elif !defined (XCODE_VERSION) /* some defaults that would otherwise be guessed by configure */
+#else  /* some defaults that would otherwise be guessed by configure */
 #   define PACKAGE_NAME "MrBayes"
 #   define PACKAGE_VERSION "3.2.8"
 #   define HOST_CPU "x86_64"
 #   define VERSION_NUMBER  PACKAGE_VERSION
 #   undef  HAVE_LIBREADLINE
 #   define UNIX_VERSION 1
-#   define SSE_ENABLED  1
+#   undef  SSE_ENABLED
 #   undef  AVX_ENABLED
 #   undef  FMA_ENABLED
 #   undef  MPI_ENABLED

--- a/src/model.c
+++ b/src/model.c
@@ -1983,7 +1983,7 @@ int CheckModel (void)
                 else if (modelParams[t->relParts[0]].treeAgePr.prior == offsetExponential ||
                          modelParams[t->relParts[0]].treeAgePr.prior == offsetGamma ||
                          modelParams[t->relParts[0]].treeAgePr.prior == truncatedNormal ||
-                        modelParams[t->relParts[0]].treeAgePr.prior == offsetLogNormal)
+                         modelParams[t->relParts[0]].treeAgePr.prior == offsetLogNormal)
                     {
                     if (treeAge < modelParams[t->relParts[0]].treeAgePr.priorParams[0])
                         {    


### PR DESCRIPTION
I think the code in some other places has been changed, so that defining SSE_ENABLED at that place makes the IDE (XCode) complains about it and the code fails to compile. It should be fine to undefine it by default and let the configure script to pick up SEE, AVX, etc during compilation or afterwards.