### PR TITLE
fix: Cannot compile MrBayes on ARM64 with BEAGLE (#302)

### DIFF
--- a/src/mcmc.c
+++ b/src/mcmc.c
@@ -5879,7 +5879,9 @@ int InitChainCondLikes (void)
         if (m->useBeagle == YES)
             {
             m->useVec = VEC_NONE;
+#           if defined (SSE_ENABLED)
             m->numFloatsPerVec = 0;
+#           endif
             }
 #       endif
 


### PR DESCRIPTION
numFloatsPerVec only exists when SSE_ENABLED. Fix ARM64 BEAGLE builds where SSE is unavailable.